### PR TITLE
ci: v0.3 — CI Pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - ci
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     labels:
       - ci
 
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - ci
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: vanishd:ci
           format: table

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - run: pip install flake8
+
+      - name: flake8
+        run: flake8 app/ --max-line-length=100
+
+      - name: hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
+  sast:
+    name: SAST
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - run: pip install bandit
+
+      - name: bandit
+        run: bandit -r app/ -ll
+
+  build-and-scan:
+    name: Build & Scan
+    runs-on: ubuntu-latest
+    needs: sast
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: vanishd:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: vanishd:ci
+          format: table
+          exit-code: "1"
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: SonarCloud scan
+        uses: SonarSource/sonarcloud-github-action@v3
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## O que foi feito

Pipeline CI completo em `.github/workflows/ci.yml` + Dependabot.

### Stages e ordem de execução

```
lint (flake8 + hadolint)
  └─> sast (bandit -ll)
        └─> build-and-scan (docker buildx + Trivy)
  └─> sonarcloud (paralelo ao sast)
```

- **lint** — `flake8 app/` (max-line-length=100) + `hadolint Dockerfile`
- **sast** — `bandit -r app/ -ll` (severity MEDIUM e acima)
- **build-and-scan** — `docker/build-push-action` com cache GHA + Trivy (exit-code 1 em CRITICAL/HIGH não fixadas)
- **sonarcloud** — análise de qualidade e security hotspots (requer `SONAR_TOKEN` secret)
- **dependabot** — atualização semanal de pip e github-actions, PRs com label `ci`

### Configurações de segurança
- `permissions: contents: read` no workflow (GITHUB_TOKEN mínimo)
- Trivy com `ignore-unfixed: true` para não falhar em CVEs sem fix disponível
- Bandit em nível MEDIUM (`-ll`) para capturar issues relevantes sem ruído excessivo

### Pré-requisito para SonarCloud
Adicionar o secret `SONAR_TOKEN` em _Settings → Secrets → Actions_ e criar o projeto em [sonarcloud.io](https://sonarcloud.io). Sem o secret, esse job falha — é esperado até a configuração.

## Closes

Closes #11, Closes #12, Closes #13, Closes #14, Closes #15, Closes #16

## Checklist de revisão

- [ ] CI dispara no push para main e em PRs
- [ ] lint, sast e build-and-scan passam
- [ ] Trivy não encontra CVEs CRITICAL/HIGH sem fix
- [ ] SonarCloud configurado com `SONAR_TOKEN` (pode ficar para depois)
- [ ] Dependabot ativado e criando PRs semanais