### PR TITLE
chore: CODEOWNERS — @NatanRigailo em todos os arquivos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @NatanRigailo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,4 +95,5 @@ jobs:
       - name: SonarCloud scan
         uses: SonarSource/sonarcloud-github-action@v5
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
CODEOWNERS ficou preso na branch da v0.3 e não chegou em main. PR pequeno só para corrigir isso.