### PR TITLE
fix: CI roda apenas em PRs, release cuida do main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Problema
`ci.yml` tinha `push: branches: [main]` além de `pull_request`, fazendo ambos CI e Release dispararem em todo merge — o CI era redundante pois o código já foi validado no PR.

## Fix
Removido `push: branches: [main]` do `ci.yml`. Agora:
- **CI** → roda apenas em PRs (validação antes do merge)
- **Release** → roda apenas em push para main (após merge)

## Sobre o release "não rodando"
O `release.yml` estava rodando e passando. As releases `v0.0.1` e `v0.0.2` já foram criadas no GitHub. Pode ter sido questão de timing ao verificar.

Closes #43