### PR TITLE
feat: /healthz com verificação do banco de dados

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -12,6 +12,14 @@ def get_db():
     return conn
 
 
+def ping_db():
+    conn = get_db()
+    try:
+        conn.execute("SELECT 1")
+    finally:
+        conn.close()
+
+
 def init_db():
     db_dir = os.path.dirname(DATABASE_PATH)
     if db_dir:

--- a/app/routes.py
+++ b/app/routes.py
@@ -8,7 +8,7 @@ from flask import Blueprint, jsonify, render_template, request
 from flask_limiter.errors import RateLimitExceeded
 
 from app import limiter
-from app.db import get_db
+from app.db import get_db, ping_db
 
 log = logging.getLogger(__name__)
 bp = Blueprint("main", __name__)
@@ -34,7 +34,16 @@ def handle_too_large(e):
 
 @bp.route("/healthz", methods=["GET"])
 def healthz():
-    return jsonify({"status": "ok", "time": int(time.time())})
+    try:
+        ping_db()
+        db_status = "ok"
+    except Exception:
+        log.exception("healthz_db_error")
+        db_status = "error"
+
+    status = "ok" if db_status == "ok" else "error"
+    code = 200 if status == "ok" else 503
+    return jsonify({"status": status, "db": db_status, "time": int(time.time())}), code
 
 
 @bp.route("/", methods=["GET"])


### PR DESCRIPTION
## O que foi feito

Torna o `/healthz` útil para monitoramento real: além de confirmar que o processo está vivo, agora verifica se o SQLite responde.

**Comportamento:**
- DB ok → `{"status": "ok", "db": "ok", "time": ...}` — HTTP 200
- DB falhou → `{"status": "error", "db": "error", "time": ...}` — HTTP 503

**Implementação:**
- `ping_db()` em `db.py` — abre conexão e executa `SELECT 1`
- `healthz()` em `routes.py` — chama `ping_db()`, determina status e código HTTP

## Checklist

- [x] Retorna 503 quando banco não responde
- [x] Campo `db` no payload para distinguir falha de app vs. falha de DB
- [x] Erro logado com `log.exception` para rastreabilidade

Closes #52