### PR TITLE
chore: pre-commit hooks e actionlint no CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
         with:
           dockerfile: Dockerfile
 
+      - name: actionlint
+        run: |
+          curl -sLo /tmp/dl-actionlint.bash \
+            https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash
+          bash /tmp/dl-actionlint.bash 1.7.7
+          ./actionlint -color
+
   sast:
     name: SAST
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        args: [--max-line-length=100]
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.3
+    hooks:
+      - id: bandit
+        args: [-ll]
+        files: ^app/
+
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ clean: down
 	docker rmi $(IMAGE_NAME) || true
 
 dev:
-	pip install pre-commit
-	pre-commit install
+	pip install --user --break-system-packages pre-commit || pip install pre-commit
+	pre-commit install 2>/dev/null || ~/.local/bin/pre-commit install
 
 lint:
 	flake8 app/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ IMAGE_NAME ?= vanishd
 PORT       ?= 8080
 DATA_VOL   ?= vanishd_data
 
-.PHONY: up down build lint clean logs shell
+.PHONY: up down build lint clean logs shell dev
 
 build:
 	docker build -t $(IMAGE_NAME) .
@@ -20,6 +20,10 @@ down:
 clean: down
 	docker volume rm $(DATA_VOL) || true
 	docker rmi $(IMAGE_NAME) || true
+
+dev:
+	pip install pre-commit
+	pre-commit install
 
 lint:
 	flake8 app/


### PR DESCRIPTION
## O que foi feito

Fecha duas issues de qualidade do ciclo v0.6:

**#45 — pre-commit hooks**

Cria `.pre-commit-config.yaml` com os hooks que espelham o CI:

| Hook | O que faz |
|---|---|
| `trailing-whitespace` | Remove espaços no fim de linha |
| `end-of-file-fixer` | Garante newline no fim do arquivo |
| `check-yaml` | Valida YAML |
| `flake8` | Lint Python (`--max-line-length=100`) |
| `bandit` | SAST Python (`-ll`, apenas `app/`) |
| `hadolint` | Lint Dockerfile |
| `actionlint` | Valida sintaxe dos workflows |

Instalar localmente:
```bash
make dev   # pip install pre-commit && pre-commit install
```

**#54 — actionlint no CI**

Adiciona step `actionlint` no job `lint` do `ci.yml`. Baixa o binário v1.7.7 via script oficial e valida todos os workflows a cada PR.

## Checklist

- [x] `.pre-commit-config.yaml` com 7 hooks
- [x] `make dev` para onboarding local
- [x] actionlint no job lint do CI (após hadolint)
- [x] Versões dos hooks pinadas

Closes #45
Closes #54