### PR TITLE
refactor: corrigir code smells JavaScript apontados pelo SonarCloud

### DIFF
--- a/app/static/create.js
+++ b/app/static/create.js
@@ -1,4 +1,4 @@
-import VanishCrypto from '/static/crypto.js';
+import VanishCrypto from './crypto.js';
 
 let mode = 'link';
 

--- a/app/static/create.js
+++ b/app/static/create.js
@@ -1,3 +1,5 @@
+import VanishCrypto from '/static/crypto.js';
+
 let mode = 'link';
 
 document.querySelectorAll('.mode-btn').forEach(btn => {
@@ -13,7 +15,7 @@ document.getElementById('submit-btn').addEventListener('click', async () => {
   const secret = document.getElementById('secret').value.trim();
   if (!secret) { alert('Digite o secret.'); return; }
 
-  const ttl = parseInt(document.getElementById('ttl').value);
+  const ttl = Number.parseInt(document.getElementById('ttl').value);
   const btn = document.getElementById('submit-btn');
   btn.disabled = true;
   btn.textContent = mode === 'password' ? 'Derivando chave...' : 'Cifrando...';

--- a/app/static/crypto.js
+++ b/app/static/crypto.js
@@ -1,12 +1,12 @@
 const VanishCrypto = (() => {
   function _b64(u8) {
     let s = '';
-    for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]);
+    for (const byte of u8) s += String.fromCodePoint(byte);
     return btoa(s);
   }
 
   function _from64(b64) {
-    return Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+    return Uint8Array.from(atob(b64), c => c.codePointAt(0));
   }
 
   async function generateKey() {
@@ -61,3 +61,5 @@ const VanishCrypto = (() => {
 
   return { generateKey, exportKey, importKey, deriveKey, encrypt, decrypt, randomSalt, saltToB64: _b64, b64ToBytes: _from64 };
 })();
+
+export default VanishCrypto;

--- a/app/static/view.js
+++ b/app/static/view.js
@@ -1,4 +1,4 @@
-import VanishCrypto from '/static/crypto.js';
+import VanishCrypto from './crypto.js';
 
 const secretId = document.getElementById('app').dataset.secretId;
 const keyB64 = location.hash.slice(1);

--- a/app/static/view.js
+++ b/app/static/view.js
@@ -1,3 +1,5 @@
+import VanishCrypto from '/static/crypto.js';
+
 const secretId = document.getElementById('app').dataset.secretId;
 const keyB64 = location.hash.slice(1);
 const panels = ['loading', 'password-section', 'success-section', 'error-section'];
@@ -43,14 +45,14 @@ async function decryptWithPassword(password) {
 }
 
 if (keyB64) {
-  decryptWithKey();
+  await decryptWithKey();
 } else {
   show('password-section');
-  document.getElementById('decrypt-btn').addEventListener('click', () => {
+  document.getElementById('decrypt-btn').addEventListener('click', async () => {
     const password = document.getElementById('password').value;
     if (!password) { alert('Digite a senha.'); return; }
     show('loading');
-    decryptWithPassword(password);
+    await decryptWithPassword(password);
   });
   document.getElementById('password').addEventListener('keydown', e => {
     if (e.key === 'Enter') document.getElementById('decrypt-btn').click();

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -44,6 +44,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/crypto.js"></script>
-<script src="/static/create.js"></script>
+<script type="module" src="/static/create.js"></script>
 {% endblock %}

--- a/app/templates/view.html
+++ b/app/templates/view.html
@@ -41,6 +41,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/crypto.js"></script>
-<script src="/static/view.js"></script>
+<script type="module" src="/static/view.js"></script>
 {% endblock %}


### PR DESCRIPTION
## O que foi feito

Fecha todos os findings de `crypto.js`, `create.js` e `view.js` do SonarCloud.

| Arquivo | Regra | Fix |
|---|---|---|
| `crypto.js:4` | S4138 | `for-of` em vez de `for` com índice |
| `crypto.js:4,9` | S7758 | `fromCodePoint`/`codePointAt` em vez das variantes `CharCode` |
| `create.js:16` | S7773 | `Number.parseInt` em vez de `parseInt` global |
| `view.js:46` | S7785 | top-level `await` em vez de chamar async function imediatamente |

**Mudança estrutural necessária para S7785:** top-level `await` só funciona em ES modules. Por isso:
- `crypto.js` ganhou `export default VanishCrypto`
- `create.js` e `view.js` importam via `import VanishCrypto from '/static/crypto.js'`
- Tags `<script>` nos templates receberam `type="module"`
- `<script src="crypto.js">` removido dos templates (agora carregado via import pelos módulos)
- Event listener do `decrypt-btn` em `view.js` também virou `async` para `await decryptWithPassword`

## Checklist

- [x] S4138, S7758, S7773, S7785 corrigidos
- [x] Scripts convertidos para ES modules sem quebrar funcionalidade
- [x] `crypto.js` não carregado duas vezes

Closes #59