### PR TITLE
feat: testes unitários e de integração com cobertura para SonarCloud

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,38 @@ jobs:
       - name: bandit
         run: bandit -r app/ -ll
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: pytest
+        run: pytest --cov=app --cov-report=xml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.xml
+
   build-and-scan:
     name: Build & Scan
     runs-on: ubuntu-latest
-    needs: [lint, sast]
-    if: always() && needs.lint.result == 'success' && (needs.sast.result == 'success' || needs.sast.result == 'skipped')
+    needs: [lint, sast, test]
+    if: >
+      always() &&
+      needs.lint.result == 'success' &&
+      (needs.sast.result == 'success' || needs.sast.result == 'skipped') &&
+      (needs.test.result == 'success' || needs.test.result == 'skipped')
     steps:
       - uses: actions/checkout@v6
 
@@ -87,7 +114,7 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, test]
     if: github.actor != 'dependabot[bot]'
     permissions:
       contents: read
@@ -96,6 +123,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage
 
       - name: SonarCloud scan
         uses: SonarSource/sonarqube-scan-action@v8.0.0

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ IMAGE_NAME ?= vanishd
 PORT       ?= 8080
 DATA_VOL   ?= vanishd_data
 
-.PHONY: up down build lint clean logs shell dev
+.PHONY: up down build lint test clean logs shell dev
 
 build:
 	docker build -t $(IMAGE_NAME) .
@@ -28,6 +28,9 @@ dev:
 lint:
 	flake8 app/
 	hadolint Dockerfile
+
+test:
+	pytest --cov=app --cov-report=term-missing
 
 logs:
 	docker logs -f $(IMAGE_NAME)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest==8.3.4
+pytest-cov==6.0.0
+pytest-flask==1.3.0

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,7 @@
 sonar.projectKey=NatanRigailo_vanishd
 sonar.organization=natanrigailo
 sonar.sources=app
+sonar.tests=tests
 sonar.python.version=3.12
+sonar.python.coverage.reportPaths=coverage.xml
 sonar.exclusions=**/__pycache__/**,**/*.pyc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+import app.db as _db_module
+
+
+@pytest.fixture()
+def app(tmp_path, monkeypatch):
+    monkeypatch.setattr(_db_module, "DATABASE_PATH", str(tmp_path / "test.db"))
+
+    from app import create_app
+    application = create_app()
+    application.config["TESTING"] = True
+    application.config["RATELIMIT_ENABLED"] = False
+    yield application
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,81 @@
+import time
+
+import app.db as db
+
+
+def test_healthz(client):
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["status"] == "ok"
+    assert data["db"] == "ok"
+
+
+def test_create_secret_valid(client):
+    r = client.post("/api/secrets", json={"ciphertext": "abc", "iv": "iv", "ttl": 3600})
+    assert r.status_code == 201
+    assert "id" in r.get_json()
+
+
+def test_create_secret_missing_ciphertext(client):
+    r = client.post("/api/secrets", json={"iv": "iv", "ttl": 3600})
+    assert r.status_code == 400
+
+
+def test_create_secret_missing_iv(client):
+    r = client.post("/api/secrets", json={"ciphertext": "abc", "ttl": 3600})
+    assert r.status_code == 400
+
+
+def test_create_secret_ttl_zero(client):
+    r = client.post("/api/secrets", json={"ciphertext": "abc", "iv": "iv", "ttl": 0})
+    assert r.status_code == 400
+
+
+def test_create_secret_ttl_too_large(client):
+    r = client.post("/api/secrets", json={"ciphertext": "abc", "iv": "iv", "ttl": 9999999})
+    assert r.status_code == 400
+
+
+def test_create_secret_invalid_ttl(client):
+    r = client.post("/api/secrets", json={"ciphertext": "abc", "iv": "iv", "ttl": "nan"})
+    assert r.status_code == 400
+
+
+def test_read_secret_success(client):
+    secret_id = client.post(
+        "/api/secrets", json={"ciphertext": "hello", "iv": "iv", "ttl": 3600}
+    ).get_json()["id"]
+
+    r = client.get(f"/api/secrets/{secret_id}")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["ciphertext"] == "hello"
+    assert data["iv"] == "iv"
+
+
+def test_read_secret_one_time(client):
+    secret_id = client.post(
+        "/api/secrets", json={"ciphertext": "once", "iv": "iv", "ttl": 3600}
+    ).get_json()["id"]
+
+    assert client.get(f"/api/secrets/{secret_id}").status_code == 200
+    assert client.get(f"/api/secrets/{secret_id}").status_code == 404
+
+
+def test_read_secret_not_found(client):
+    assert client.get("/api/secrets/does-not-exist").status_code == 404
+
+
+def test_read_secret_expired(client):
+    now = int(time.time())
+    conn = db.get_db()
+    conn.execute(
+        "INSERT INTO secrets (id, ciphertext, iv, salt, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("expired-id", "ct", "iv", None, now - 100, now - 1),
+    )
+    conn.commit()
+    conn.close()
+
+    assert client.get("/api/secrets/expired-id").status_code == 404

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,29 @@
+import time
+
+import app.db as db
+
+
+def test_cleanup_deletes_expired_and_keeps_active(app):
+    now = int(time.time())
+    conn = db.get_db()
+    conn.execute(
+        "INSERT INTO secrets (id, ciphertext, iv, salt, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("expired", "ct", "iv", None, now - 200, now - 1),
+    )
+    conn.execute(
+        "INSERT INTO secrets (id, ciphertext, iv, salt, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("active", "ct", "iv", None, now, now + 3600),
+    )
+    conn.commit()
+    conn.close()
+
+    conn = db.get_db()
+    conn.execute("DELETE FROM secrets WHERE expires_at <= ?", (int(time.time()),))
+    conn.commit()
+    ids = [r[0] for r in conn.execute("SELECT id FROM secrets").fetchall()]
+    conn.close()
+
+    assert "expired" not in ids
+    assert "active" in ids

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,24 @@
+import app.db as db
+
+
+def test_init_db_creates_table(app):
+    conn = db.get_db()
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='secrets'"
+        ).fetchone()
+        assert row is not None
+    finally:
+        conn.close()
+
+
+def test_get_db_returns_connection(app):
+    conn = db.get_db()
+    try:
+        assert conn.execute("SELECT 1").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_ping_db(app):
+    db.ping_db()


### PR DESCRIPTION
## O que foi feito

Suite completa de testes para fechar o v0.6.

### Cobertura — 15 testes

**`tests/test_api.py`** (integração via Flask test client):
- `POST /api/secrets`: payload válido → 201, ciphertext ausente → 400, iv ausente → 400, ttl=0 → 400, ttl acima do máximo → 400, ttl não-numérico → 400
- `GET /api/secrets/:id`: sucesso + dados corretos, one-time (segunda leitura → 404), id inexistente → 404, secret expirado → 404
- `GET /healthz`: 200 com `status: ok` e `db: ok`

**`tests/test_db.py`** (unitário):
- `init_db` cria tabela `secrets`
- `get_db` retorna conexão funcional
- `ping_db` não lança exceção

**`tests/test_cleanup.py`** (lógica de deleção):
- DELETE remove expirados e preserva ativos

### Isolamento
- Banco SQLite por teste via `tmp_path` + `monkeypatch.setattr(app.db, "DATABASE_PATH", ...)`
- Rate limiting desabilitado com `RATELIMIT_ENABLED=False`

### CI
- Novo job `test` paralelo ao `sast`
- Gera `coverage.xml` e sobe como artifact
- Job `sonarcloud` baixa o artifact antes do scan
- Job `build-and-scan` aguarda `test` além de `lint` e `sast`

### SonarCloud
- `sonar.python.coverage.reportPaths=coverage.xml`
- `sonar.tests=tests`

### Local
```bash
make test
```

Closes #47