### PR TITLE
ci: pip-audit e gitleaks no pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,13 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - run: pip install bandit
+      - run: pip install bandit pip-audit
 
       - name: bandit
         run: bandit -r app/ -ll
+
+      - name: pip-audit
+        run: pip-audit -r requirements.txt
 
   test:
     name: Test
@@ -78,15 +81,27 @@ jobs:
           name: coverage
           path: coverage.xml
 
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-and-scan:
     name: Build & Scan
     runs-on: ubuntu-latest
-    needs: [lint, sast, test]
+    needs: [lint, sast, test, secret-scan]
     if: >
       always() &&
       needs.lint.result == 'success' &&
       (needs.sast.result == 'success' || needs.sast.result == 'skipped') &&
-      (needs.test.result == 'success' || needs.test.result == 'skipped')
+      (needs.test.result == 'success' || needs.test.result == 'skipped') &&
+      (needs.secret-scan.result == 'success' || needs.secret-scan.result == 'skipped')
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## O que foi feito

Adiciona duas camadas de segurança complementares ao pipeline.

**#51 — pip-audit**

Step no job `sast`, após o bandit. Audita `requirements.txt` contra o banco de vulnerabilidades do PyPA (Advisory Database). Falha em qualquer CVE encontrado.

Complementa o Trivy, que varre OS + pacotes do sistema na imagem Docker — pip-audit foca nas dependências Python do projeto.

**#50 — gitleaks**

Job `secret-scan` independente (sem `needs`, roda em paralelo). Faz `fetch-depth: 0` para varrer o histórico completo do repositório em busca de credenciais acidentais — tokens, chaves, senhas hardcoded.

`build-and-scan` agora depende de `secret-scan` além dos jobs existentes.

## Pipeline atualizado

```
lint ──┬── sast (bandit + pip-audit)
       ├── test
       └── secret-scan (gitleaks, histórico completo)
            └── build-and-scan (Trivy)
                    └── sonarcloud
```

Closes #51
Closes #50