### PR TITLE
fix: instalar libpq5 na stage final do Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
 FROM python:3.14-slim
 
+# hadolint ignore=DL3008
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libpq5 \
+ && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd -r vanishd \
  && useradd -r -g vanishd -d /app -s /sbin/nologin vanishd
 


### PR DESCRIPTION
## Problema

O deploy no Render falha com `libpq.so.5: cannot open shared object file` quando `DATABASE_URL` está definido.

**Causa:** `psycopg2-binary` é importado lazily — só quando `DATABASE_URL` está setado. Localmente sem `DATABASE_URL` o import nunca acontece, então a lib passa despercebida. No Render com `DATABASE_URL` configurado, o import ocorre em runtime e o `libpq5` precisa estar presente na imagem.

## Solução

Adiciona `libpq5` à stage final do Dockerfile multi-stage.

## Checklist

- [x] `libpq5` adicionado à stage final
- [x] `# hadolint ignore=DL3008` mantido (sem pinned versions no apt)

Closes #77