### PR TITLE
feat: botão de revelação — secret consumido apenas ao confirmar leitura

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ As milestones e issues são gerenciadas no GitHub: https://github.com/NatanRigai
 
 ## Estado atual
 
-**Versão:** v1.0 em andamento
+**Versão:** v1.0.0 ✅
 
 **Milestones concluídas:**
 - ✅ v0.1 — Fundação: estrutura, Dockerfile multi-stage non-root, Flask skeleton, SQLite schema
@@ -135,16 +135,7 @@ As milestones e issues são gerenciadas no GitHub: https://github.com/NatanRigai
 - ✅ v0.5 — Release & Deploy: auto-tag semver, publish GHCR, deploy Render via webhook, README com badges
 - ✅ v0.6 — Quality & Dev Experience: pre-commit hooks, actionlint, JS code smells, testes (97% coverage), /healthz DB check, rate limit POST, log injection sanitization
 - ✅ v0.7 — Production Ready: suporte PostgreSQL via DATABASE_URL (_Conn wrapper, psycopg2-binary), pip-audit, gitleaks, fix libpq5 runtime (Render+Supabase via pooler IPv4 port 6543)
-
-**Issues avulsas em aberto:**
-- Issue #64: security hotspot CSRF — avaliar proteção CSRF no POST /api/secrets (SonarCloud S4502)
-
-**v1.0 — Em andamento:**
-- Issue #49: DAST com OWASP ZAP no pipeline
-- Issue #46: padronizar frontend com design system do portfólio
-- Issue #56: páginas de erro customizadas (404, 500, 413, 429)
-- Issue #55: histórico de secrets criados via localStorage
-- Issue #60: acessibilidade — associar label ao controle de modo na create page
+- ✅ v1.0 — UX & Pipeline completo: design system, favicon, fontes locais, páginas de erro customizadas (404/500/413/429), histórico localStorage com badges de estado, acessibilidade (fieldset+legend), DAST OWASP ZAP baseline no CI, CSRF via Content-Type enforcement (SonarCloud S4502), testes JS com Jest + coverage lcov
 
 **Próximas milestones:**
 - v1.1 — UX Polish: botão de revelação (expira só ao confirmar leitura) — issue #57
@@ -156,6 +147,10 @@ As milestones e issues são gerenciadas no GitHub: https://github.com/NatanRigai
 - pytest-cov gera paths absolutos; SonarCloud precisa de `relative_files = True` no `.coveragerc`
 - psycopg2-binary sem wheel para Python 3.14 — builder precisa de `libpq-dev build-essential`; stage final precisa de `libpq5`
 - Supabase no Render: DNS resolve IPv6, Render free tier não tem IPv6 outbound — usar connection pooler (porta 6543, IPv4)
+- Auto-tagger semver gera tags incrementais por PR; para alinhar com milestones do roadmap, criar a tag de milestone manualmente sobre o HEAD após o último merge
+- ZAP baseline.py vs full-scan.py: baseline (passivo) roda em CI a cada PR; full scan (ativo) é one-time local — não colocar full scan em CI
+- ZAP Docker como non-root (`zap` user): precisa de `chmod 777` no diretório de output antes do `docker run -v`
+- `sonar.tests` não aceita subdirs que causem double-indexing — manter `sonar.tests=tests` e colocar JS tests dentro de `tests/js/`
 
 ---
 

--- a/app/static/view.js
+++ b/app/static/view.js
@@ -1,8 +1,6 @@
 import VanishCrypto from './crypto.js';
 
-const secretId = document.getElementById('app').dataset.secretId;
-const keyB64 = location.hash.slice(1);
-const panels = ['loading', 'password-section', 'success-section', 'error-section'];
+const panels = ['loading', 'confirm-section', 'password-section', 'success-section', 'error-section'];
 
 function show(id) {
   panels.forEach(p => document.getElementById(p).classList.add('hidden'));
@@ -19,7 +17,7 @@ function showError(msg) {
   show('error-section');
 }
 
-async function decryptWithKey() {
+async function decryptWithKey(secretId, keyB64) {
   try {
     const res = await fetch(`/api/secrets/${secretId}`);
     if (!res.ok) { showError('Secret não encontrado, expirado ou já foi lido.'); return; }
@@ -31,7 +29,7 @@ async function decryptWithKey() {
   }
 }
 
-async function decryptWithPassword(password) {
+async function decryptWithPassword(secretId, password) {
   try {
     const res = await fetch(`/api/secrets/${secretId}`);
     if (!res.ok) { showError('Secret não encontrado, expirado ou já foi lido.'); return; }
@@ -44,17 +42,26 @@ async function decryptWithPassword(password) {
   }
 }
 
-if (keyB64) {
-  await decryptWithKey();
-} else {
-  show('password-section');
-  document.getElementById('decrypt-btn').addEventListener('click', async () => {
-    const password = document.getElementById('password').value;
-    if (!password) { alert('Digite a senha.'); return; }
-    show('loading');
-    await decryptWithPassword(password);
-  });
-  document.getElementById('password').addEventListener('keydown', e => {
-    if (e.key === 'Enter') document.getElementById('decrypt-btn').click();
-  });
+export function init(secretId, keyB64) {
+  if (keyB64) {
+    show('confirm-section');
+    document.getElementById('reveal-btn').addEventListener('click', async () => {
+      show('loading');
+      await decryptWithKey(secretId, keyB64);
+    });
+  } else {
+    show('password-section');
+    document.getElementById('decrypt-btn').addEventListener('click', async () => {
+      const password = document.getElementById('password').value;
+      if (!password) { alert('Digite a senha.'); return; }
+      show('loading');
+      await decryptWithPassword(secretId, password);
+    });
+    document.getElementById('password').addEventListener('keydown', e => {
+      if (e.key === 'Enter') document.getElementById('decrypt-btn').click();
+    });
+  }
 }
+
+const secretId = document.getElementById('app').dataset.secretId;
+init(secretId, location.hash.slice(1));

--- a/app/templates/view.html
+++ b/app/templates/view.html
@@ -6,9 +6,18 @@
 
   <div id="app" data-secret-id="{{ secret_id }}" hidden></div>
 
-  <div id="loading">
+  <div id="loading" class="hidden">
     <div class="spinner"></div>
     <p class="text-muted" style="text-align:center">Decifrando...</p>
+  </div>
+
+  <div id="confirm-section">
+    <div class="badge badge-warning">Uso único</div>
+    <p class="text-muted" style="margin-top:1rem;margin-bottom:1.5rem">
+      Este secret será <strong>destruído permanentemente</strong> ao ser revelado.
+      Certifique-se de estar em um ambiente confiável antes de continuar.
+    </p>
+    <button class="btn" id="reveal-btn" type="button">Revelar secret</button>
   </div>
 
   <div id="password-section" class="hidden">

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "testEnvironment": "jsdom",
     "coverageDirectory": "coverage-js",
     "coverageReporters": ["lcov", "text"],
-    "collectCoverageFrom": ["app/static/history.js"]
+    "collectCoverageFrom": ["app/static/history.js", "app/static/view.js"]
   }
 }

--- a/tests/js/view.test.js
+++ b/tests/js/view.test.js
@@ -1,0 +1,196 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+
+const MOCK_SECRET_ID = 'abc123';
+const MOCK_KEY_B64 = 'c29tZWtleQ==';
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <div id="app" data-secret-id="${MOCK_SECRET_ID}"></div>
+    <div id="loading" class="hidden"></div>
+    <div id="confirm-section"></div>
+    <div id="password-section" class="hidden"></div>
+    <div id="success-section" class="hidden"></div>
+    <div id="error-section" class="hidden"></div>
+    <button id="reveal-btn" type="button">Revelar secret</button>
+    <button id="decrypt-btn" type="button">Decifrar</button>
+    <input id="password" type="password" />
+    <div id="secret-content"></div>
+    <p id="error-msg"></p>
+  `;
+}
+
+function isVisible(id) {
+  return !document.getElementById(id).classList.contains('hidden');
+}
+
+jest.unstable_mockModule('../../app/static/crypto.js', () => ({
+  default: {
+    importKey: jest.fn().mockResolvedValue('mock-key'),
+    decrypt: jest.fn().mockResolvedValue('my-secret-text'),
+    deriveKey: jest.fn().mockResolvedValue('mock-key'),
+    b64ToBytes: jest.fn().mockReturnValue(new Uint8Array(16)),
+  },
+}));
+
+describe('view — link mode', () => {
+  let init;
+
+  beforeEach(async () => {
+    setupDOM();
+    jest.resetModules();
+    const mod = await import('../../app/static/view.js');
+    init = mod.init;
+  });
+
+  test('shows confirm-section on init', () => {
+    init(MOCK_SECRET_ID, MOCK_KEY_B64);
+    expect(isVisible('confirm-section')).toBe(true);
+    expect(isVisible('password-section')).toBe(false);
+    expect(isVisible('loading')).toBe(false);
+  });
+
+  test('does not fetch before reveal click', () => {
+    global.fetch = jest.fn();
+    init(MOCK_SECRET_ID, MOCK_KEY_B64);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('shows loading and calls fetch on reveal click', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ciphertext: 'ct', iv: 'iv' }),
+    });
+    init(MOCK_SECRET_ID, MOCK_KEY_B64);
+    document.getElementById('reveal-btn').click();
+    await Promise.resolve();
+    expect(global.fetch).toHaveBeenCalledWith(`/api/secrets/${MOCK_SECRET_ID}`);
+  });
+
+  test('shows success section after reveal with valid response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ciphertext: 'ct', iv: 'iv' }),
+    });
+    init(MOCK_SECRET_ID, MOCK_KEY_B64);
+    document.getElementById('reveal-btn').click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(isVisible('success-section')).toBe(true);
+    expect(document.getElementById('secret-content').textContent).toBe('my-secret-text');
+  });
+
+  test('shows error section when fetch returns not-ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false });
+    init(MOCK_SECRET_ID, MOCK_KEY_B64);
+    document.getElementById('reveal-btn').click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(isVisible('error-section')).toBe(true);
+    expect(document.getElementById('error-msg').textContent).toMatch(/não encontrado/);
+  });
+
+  test('shows error section when fetch throws', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network'));
+    init(MOCK_SECRET_ID, MOCK_KEY_B64);
+    document.getElementById('reveal-btn').click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(isVisible('error-section')).toBe(true);
+    expect(document.getElementById('error-msg').textContent).toMatch(/corrompido/);
+  });
+});
+
+describe('view — password mode', () => {
+  let init;
+
+  beforeEach(async () => {
+    setupDOM();
+    jest.resetModules();
+    const mod = await import('../../app/static/view.js');
+    init = mod.init;
+  });
+
+  test('shows password-section when no key', () => {
+    init(MOCK_SECRET_ID, '');
+    expect(isVisible('password-section')).toBe(true);
+    expect(isVisible('confirm-section')).toBe(false);
+    expect(isVisible('loading')).toBe(false);
+  });
+
+  test('does not fetch before decrypt click', () => {
+    global.fetch = jest.fn();
+    init(MOCK_SECRET_ID, '');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('alerts when decrypt clicked with empty password', () => {
+    global.alert = jest.fn();
+    global.fetch = jest.fn();
+    init(MOCK_SECRET_ID, '');
+    document.getElementById('decrypt-btn').click();
+    expect(global.alert).toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('calls fetch with password on decrypt click', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ciphertext: 'ct', iv: 'iv', salt: 'c2FsdA==' }),
+    });
+    init(MOCK_SECRET_ID, '');
+    document.getElementById('password').value = 'mypassword';
+    document.getElementById('decrypt-btn').click();
+    await Promise.resolve();
+    expect(global.fetch).toHaveBeenCalledWith(`/api/secrets/${MOCK_SECRET_ID}`);
+  });
+
+  test('shows success after correct password', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ciphertext: 'ct', iv: 'iv', salt: 'c2FsdA==' }),
+    });
+    init(MOCK_SECRET_ID, '');
+    document.getElementById('password').value = 'mypassword';
+    document.getElementById('decrypt-btn').click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(isVisible('success-section')).toBe(true);
+  });
+
+  test('enter key on password input triggers decrypt', () => {
+    global.fetch = jest.fn();
+    init(MOCK_SECRET_ID, '');
+    const clickSpy = jest.spyOn(document.getElementById('decrypt-btn'), 'click');
+    const event = new KeyboardEvent('keydown', { key: 'Enter' });
+    document.getElementById('password').dispatchEvent(event);
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  test('shows error when secret has no salt', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ciphertext: 'ct', iv: 'iv' }),
+    });
+    init(MOCK_SECRET_ID, '');
+    document.getElementById('password').value = 'mypassword';
+    document.getElementById('decrypt-btn').click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(isVisible('error-section')).toBe(true);
+    expect(document.getElementById('error-msg').textContent).toMatch(/não usa modo senha/);
+  });
+
+  test('shows error when fetch returns not-ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false });
+    init(MOCK_SECRET_ID, '');
+    document.getElementById('password').value = 'mypassword';
+    document.getElementById('decrypt-btn').click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(isVisible('error-section')).toBe(true);
+  });
+
+  test('shows error when fetch throws', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network'));
+    init(MOCK_SECRET_ID, '');
+    document.getElementById('password').value = 'mypassword';
+    document.getElementById('decrypt-btn').click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(isVisible('error-section')).toBe(true);
+    expect(document.getElementById('error-msg').textContent).toMatch(/incorreta/);
+  });
+});


### PR DESCRIPTION
Closes #57

## O que muda

Antes, abrir um link de secret no modo link disparava imediatamente o `GET /api/secrets/:id`, consumindo o secret. Isso tornava qualquer preview de link (Slack, WhatsApp, iOS Messages) um vetor de consumo acidental.

Agora o fluxo do **modo link** é:

```
abre o link → tela de confirmação → clica "Revelar secret" → fetch + decrypt → exibe
```

O **modo senha** permanece inalterado — a digitação da senha já é a confirmação explícita.

## Implementação

- `view.html`: novo panel `confirm-section` com badge "Uso único" e botão "Revelar secret"; `loading` começa hidden
- `view.js`: refatorado para exportar `init(secretId, keyB64)` — o fetch só ocorre no listener do botão; módulo chama `init` com `location.hash` ao carregar
- `view.test.js`: 15 testes novos cobrindo link mode (confirm → loading → success/error) e password mode (sem regressão); coverage view.js = 100% stmts/lines

## Checklist

- [x] `GET /api/secrets/:id` só é chamado após clique em "Revelar secret" (link mode)
- [x] Tela de confirmação exibe aviso de uso único
- [x] Modo senha mantém fluxo atual
- [x] 39 testes JS passando (24 history + 15 view)
- [x] 35 testes Python passando, 98% coverage
- [x] flake8 limpo