### PR TITLE
fix: use single quotes for data-i18n attribute to avoid JSON quote collision

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/static/fonts.css">
   <link rel="stylesheet" href="/static/style.css">
 </head>
-<body data-i18n="{{ t | tojson }}">
+<body data-i18n='{{ t | tojson }}'>
   <header>
     <a href="/" class="logo">vanish<em>d</em></a>
     <p class="tagline">zero-knowledge &middot; one-time &middot; self-hosted</p>


### PR DESCRIPTION
## Problem

`<body data-i18n="{{ t | tojson }}">` — the browser terminates the attribute at the first `"` inside the JSON, so `dataset.i18n` arrives in JS as just `{`. `JSON.parse` then throws:

```
Uncaught SyntaxError: Expected property name or '}' in JSON at position 1
    at JSON.parse (<anonymous>)
    at create.js:4:16
```

## Fix

Use single quotes as the attribute delimiter:

```html
<body data-i18n='{{ t | tojson }}'>
```

Flask's `tojson` already escapes `'` as `'`, so the value never contains a literal single quote — safe to use as attribute delimiter.

## Note

This fix was committed to the already-merged `feat/i18n-language-switcher` branch (PR #98) before the merge was noticed. Cherry-picked to this branch from `0295de0`.