### PR TITLE
feat: endpoint /metrics para Prometheus

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,8 @@
 import logging
 import os
+import time
 
-from flask import Flask, request
+from flask import Flask, g, request
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 
@@ -36,6 +37,8 @@ def create_app():
     from app.routes import bp
     app.register_blueprint(bp)
 
+    app.before_request(_start_timer)
+    app.after_request(_record_request_duration)
     app.after_request(_set_security_headers)
     app.after_request(_set_lang_cookie)
 
@@ -46,6 +49,20 @@ def create_app():
         return {'t': get_t(), 'lang': get_locale()}
 
     return app
+
+
+def _start_timer():
+    g.start_time = time.time()
+
+
+def _record_request_duration(response):
+    if hasattr(g, "start_time") and request.endpoint != "main.metrics":
+        from app.metrics import request_duration
+        route = str(request.url_rule) if request.url_rule else "unknown"
+        request_duration.labels(route=route, method=request.method).observe(
+            time.time() - g.start_time
+        )
+    return response
 
 
 def _set_lang_cookie(response):

--- a/app/cleanup.py
+++ b/app/cleanup.py
@@ -4,6 +4,7 @@ import threading
 import time
 
 from app.db import get_db
+from app.metrics import secrets_expired
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +19,7 @@ def cleanup_once():
         )
         conn.commit()
         if result.rowcount:
+            secrets_expired.inc(result.rowcount)
             log.info("cleanup_expired count=%d", result.rowcount)
     finally:
         conn.close()

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,23 @@
+from prometheus_client import Counter, Histogram
+
+secrets_created = Counter(
+    "vanishd_secrets_created_total",
+    "Secrets created successfully",
+)
+secrets_read = Counter(
+    "vanishd_secrets_read_total",
+    "Secrets read (consumed)",
+)
+secrets_expired = Counter(
+    "vanishd_secrets_expired_total",
+    "Secrets removed by the cleanup job",
+)
+secrets_not_found = Counter(
+    "vanishd_secrets_not_found_total",
+    "Read attempts with no result (expired or already read)",
+)
+request_duration = Histogram(
+    "vanishd_request_duration_seconds",
+    "Request latency by route and method",
+    ["route", "method"],
+)

--- a/app/routes.py
+++ b/app/routes.py
@@ -6,10 +6,12 @@ import uuid
 
 from flask import Blueprint, jsonify, render_template, request
 from flask_limiter.errors import RateLimitExceeded
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from app import limiter
 from app.db import get_db, ping_db
 from app.i18n import get_t
+from app.metrics import secrets_created, secrets_not_found, secrets_read
 
 log = logging.getLogger(__name__)
 bp = Blueprint("main", __name__)
@@ -56,6 +58,11 @@ def handle_server_error(e):
     if _wants_json():
         return jsonify({"error": "internal server error"}), 500
     return _error_page(500, get_t()["err_server"])
+
+
+@bp.route("/metrics", methods=["GET"])
+def metrics():
+    return generate_latest(), 200, {"Content-Type": CONTENT_TYPE_LATEST}
 
 
 @bp.route("/healthz", methods=["GET"])
@@ -116,6 +123,7 @@ def create_secret():
     finally:
         conn.close()
 
+    secrets_created.inc()
     log.info("secret_created id=%s ttl=%d", secret_id, ttl)
     return jsonify({"id": secret_id}), 201
 
@@ -149,10 +157,12 @@ def read_secret(secret_id):
         conn.close()
 
     if row is None:
+        secrets_not_found.inc()
         log.warning(
             "secret_not_found id=%s ip=%s", _sanitize(secret_id), _sanitize(request.remote_addr)
         )
         return jsonify({"error": "secret not found or expired"}), 404
 
+    secrets_read.inc()
     log.info("secret_read id=%s ip=%s", _sanitize(secret_id), _sanitize(request.remote_addr))
     return jsonify({"ciphertext": row["ciphertext"], "iv": row["iv"], "salt": row["salt"]})

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask==3.1.3
 flask-limiter==4.1.1
 waitress==3.0.2
 psycopg2-binary==2.9.10
+prometheus_client==0.21.1

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,97 @@
+import time
+
+import pytest
+from prometheus_client import REGISTRY
+
+import app.db as _db_module
+
+
+@pytest.fixture()
+def app(tmp_path, monkeypatch):
+    monkeypatch.setattr(_db_module, "DATABASE_PATH", str(tmp_path / "test.db"))
+    from app import create_app
+    application = create_app()
+    application.config["TESTING"] = True
+    application.config["RATELIMIT_ENABLED"] = False
+    yield application
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _val(name, labels=None):
+    v = REGISTRY.get_sample_value(name, labels or {})
+    return v or 0.0
+
+
+def _post_secret(client, ttl=60):
+    return client.post(
+        "/api/secrets",
+        json={"ciphertext": "abc", "iv": "def", "ttl": ttl},
+        content_type="application/json",
+    )
+
+
+def test_create_increments_counter(client):
+    before = _val("vanishd_secrets_created_total")
+    resp = _post_secret(client)
+    assert resp.status_code == 201
+    assert _val("vanishd_secrets_created_total") - before == 1.0
+
+
+def test_read_increments_counter(client):
+    secret_id = _post_secret(client).get_json()["id"]
+    before = _val("vanishd_secrets_read_total")
+    resp = client.get(f"/api/secrets/{secret_id}")
+    assert resp.status_code == 200
+    assert _val("vanishd_secrets_read_total") - before == 1.0
+
+
+def test_not_found_increments_counter(client):
+    before = _val("vanishd_secrets_not_found_total")
+    resp = client.get("/api/secrets/nonexistent-id")
+    assert resp.status_code == 404
+    assert _val("vanishd_secrets_not_found_total") - before == 1.0
+
+
+def test_cleanup_increments_expired_counter(app):
+    import app.db as db
+    from app.cleanup import cleanup_once
+
+    now = int(time.time())
+    conn = db.get_db()
+    conn.execute(
+        "INSERT INTO secrets (id, ciphertext, iv, salt, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("exp1", "ct", "iv", None, now - 200, now - 1),
+    )
+    conn.execute(
+        "INSERT INTO secrets (id, ciphertext, iv, salt, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("exp2", "ct", "iv", None, now - 200, now - 1),
+    )
+    conn.commit()
+    conn.close()
+
+    before = _val("vanishd_secrets_expired_total")
+    cleanup_once()
+    assert _val("vanishd_secrets_expired_total") - before == 2.0
+
+
+def test_metrics_endpoint_returns_prometheus_format(client):
+    _post_secret(client)
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert b"vanishd_secrets_created_total" in resp.data
+    assert b"TYPE vanishd_secrets_created_total counter" in resp.data
+
+
+def test_request_duration_histogram_recorded(client):
+    _post_secret(client)
+    count = REGISTRY.get_sample_value(
+        "vanishd_request_duration_seconds_count",
+        {"route": "/api/secrets", "method": "POST"},
+    )
+    assert count is not None and count >= 1.0


### PR DESCRIPTION
Closes #88

## O que foi feito

Expõe métricas da aplicação via `GET /metrics` no formato Prometheus, usando `prometheus_client`.

### Métricas implementadas

| Métrica | Tipo | Onde é incrementada |
|---------|------|---------------------|
| `vanishd_secrets_created_total` | Counter | `create_secret()` após INSERT com sucesso |
| `vanishd_secrets_read_total` | Counter | `read_secret()` após DELETE+RETURNING retornar linha |
| `vanishd_secrets_not_found_total` | Counter | `read_secret()` quando nenhuma linha é retornada |
| `vanishd_secrets_expired_total` | Counter | `cleanup_once()` incrementado com `result.rowcount` |
| `vanishd_request_duration_seconds` | Histogram | `after_request` hook — labels `route` (padrão da URL) + `method` |

### Detalhes de implementação

- `app/metrics.py` — definição central de todos os instrumentos
- `app/__init__.py` — hooks `before_request`/`after_request` para o histogram; `/metrics` excluído da instrumentação para não criar ruído
- Label `route` usa `str(request.url_rule)` (ex: `/api/secrets/<secret_id>`) para evitar alta cardinalidade
- Multiprocess mode desabilitado — instância única, registry padrão

## Checklist de review

- [x] `GET /metrics` retorna formato Prometheus válido
- [x] Contadores incrementam +1 por operação
- [x] Histograma registrado com labels `route` e `method`
- [x] Cleanup job incrementa `vanishd_secrets_expired_total` com o rowcount real
- [x] 6 testes unitários (delta-based — sem reset de registry global)
- [x] Suite completa: 48/48 passando, cobertura 98%
- [x] pre-commit: flake8 + bandit passando